### PR TITLE
fix: de-reference pointer objects correctly

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -120,7 +120,8 @@ export class RegistryTokens implements Authenticator {
       // PULL or PUSH methods
       case "HEAD":
         // HEAD requests can be used by pushers like docker
-        if (!payload.capabilities.includes("pull") || !payload.capabilities.includes("push")) {
+        // accept either pull or push, since clients may HEAD before deciding which flow to use
+        if (!payload.capabilities.includes("pull") && !payload.capabilities.includes("push")) {
           console.warn(
             `verifyToken: failed jwt verification: missing any capability for HEAD request in ${request.url}`,
           );
@@ -206,6 +207,8 @@ export class RegistryTokens implements Authenticator {
 }
 
 const checkHasPermissionToImage = (payload: RegistryAuthProtocolTokenPayload, request: Request) => {
+  // if the token isn't scoped to an image, don't enforce image matching
+  if (!payload?.imageName) return true;
   const split = request.url.split("/");
   let hasImageName = false;
   for (const part of split) {


### PR DESCRIPTION
there's many legacy images that store large layers in a top level key (usually just an arbitrary UUID) since R2 does not allow moving objects bigger than 5GB. The registry would then place a stub file with the metadata `X-Serverless-Registry-Reference: [UUID]` & resolve this on HEAD and GET requests to the layer. Layers of this type wont be created going forward, because all layers bigger than 512MB are being uploaded via presigned multipart URLs, but these legacy reference layers still exist. Somehow this logic was dropped in merge commits and caused a slow buildup of config validation errors since machines would pull these stub files expecting them to be valid layers.

This PR adds back that logic to dereference these pointer files on HEAD and GET requests to layers.