### PR TITLE
fix: scope destructive registry routes and require delete capability

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 import { decode } from "@cfworker/base64url";
 import { errorString } from "./utils";
 
-export type RegistryTokenCapability = "push" | "pull";
+export type RegistryTokenCapability = "push" | "pull" | "delete";
 export type RegistryAuthProtocolTokenPayload = {
   username: string;
   account_id?: string;

--- a/src/authentication-method.ts
+++ b/src/authentication-method.ts
@@ -8,7 +8,7 @@ export async function authenticationMethodFromEnv(env: Env) {
     return await newRegistryTokens(env.JWT_REGISTRY_TOKENS_PUBLIC_KEY);
   } else if (env.USERNAME && env.PASSWORD) {
     const credentials: AuthenticatorCredentials[] = [
-      { username: env.USERNAME, password: env.PASSWORD, capabilities: ["pull", "push"] }
+      { username: env.USERNAME, password: env.PASSWORD, capabilities: ["pull", "push", "delete"] }
     ];
 
     if (env.READONLY_USERNAME && env.READONLY_PASSWORD) {

--- a/src/token.ts
+++ b/src/token.ts
@@ -78,6 +78,10 @@ export class RegistryTokens implements Authenticator {
     return request.url.endsWith("/v2/");
   }
 
+  static checkIfGarbageCollectionPath(request: Request): boolean {
+    return new URL(request.url).pathname.endsWith("/gc");
+  }
+
   async verifyToken(
     request: Request,
     token: string,
@@ -165,6 +169,29 @@ export class RegistryTokens implements Authenticator {
 
       // PUSH methods
       case "POST":
+        // garbage collection is a destructive operation, it requires the "delete" capability
+        if (RegistryTokens.checkIfGarbageCollectionPath(request)) {
+          if (!payload.capabilities.includes("delete")) {
+            console.warn(
+              `verifyToken: failed jwt verification: missing "delete" capability for ${request.method} HTTP method in ${request.url}`,
+            );
+            return { verified: false, payload: null };
+          }
+        } else if (!payload.capabilities.includes("push")) {
+          console.warn(
+            `verifyToken: failed jwt verification: missing "push" capability for ${request.method} HTTP method`,
+          );
+          return { verified: false, payload: null };
+        }
+        if (!checkHasPermissionToImage(payload, request)) {
+          console.warn(
+            `verifyToken: failed jwt verification: image name ${payload?.imageName} does not match the token's image name in ${request.url}`,
+          );
+          return { verified: false, payload: null };
+        }
+        break;
+      case "PUT":
+      case "PATCH":
         if (!payload.capabilities.includes("push")) {
           console.warn(
             `verifyToken: failed jwt verification: missing "push" capability for ${request.method} HTTP method`,
@@ -177,12 +204,18 @@ export class RegistryTokens implements Authenticator {
           );
           return { verified: false, payload: null };
         }
-      case "PUT":
+        break;
+      // DELETE is a destructive operation, it requires an explicit "delete" capability
       case "DELETE":
-      case "PATCH":
-        if (!payload.capabilities.includes("push")) {
+        if (!payload.capabilities.includes("delete")) {
           console.warn(
-            `verifyToken: failed jwt verification: missing "push" capability for ${request.method} HTTP method`,
+            `verifyToken: failed jwt verification: missing "delete" capability for ${request.method} HTTP method in ${request.url}`,
+          );
+          return { verified: false, payload: null };
+        }
+        if (!checkHasPermissionToImage(payload, request)) {
+          console.warn(
+            `verifyToken: failed jwt verification: image name ${payload?.imageName} does not match the token's image name in ${request.url}`,
           );
           return { verified: false, payload: null };
         }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -348,13 +348,55 @@ describe("tokens", async () => {
     expect(verified).toBeTruthy();
   });
 
-  test("auth payload push on /v2/whatever with mutations", async () => {
-    for (const mutationMethod of ["PATCH", "POST", "DELETE"]) {
+  test("auth payload push on /v2/whatever with push mutations", async () => {
+    for (const mutationMethod of ["PATCH", "POST"]) {
       const { verified } = RegistryTokens.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
         capabilities: ["push"],
       } as RegistryAuthProtocolTokenPayload);
       expect(verified).toBeTruthy();
     }
+  });
+
+  test("auth payload push without delete cannot DELETE", async () => {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("DELETE", "/v2/whatever/manifests/sha256:abc", null), {
+      capabilities: ["push"],
+    } as RegistryAuthProtocolTokenPayload);
+    expect(verified).toBeFalsy();
+  });
+
+  test("auth payload push without delete cannot run gc", async () => {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("POST", "/v2/whatever/gc", null), {
+      capabilities: ["push"],
+    } as RegistryAuthProtocolTokenPayload);
+    expect(verified).toBeFalsy();
+  });
+
+  test("auth payload delete can DELETE and run gc", async () => {
+    const del = RegistryTokens.verifyPayload(createRequest("DELETE", "/v2/whatever/manifests/sha256:abc", null), {
+      capabilities: ["delete"],
+    } as RegistryAuthProtocolTokenPayload);
+    expect(del.verified).toBeTruthy();
+
+    const gc = RegistryTokens.verifyPayload(createRequest("POST", "/v2/whatever/gc", null), {
+      capabilities: ["delete"],
+    } as RegistryAuthProtocolTokenPayload);
+    expect(gc.verified).toBeTruthy();
+  });
+
+  test("auth payload delete scoped to another image cannot DELETE", async () => {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("DELETE", "/v2/whatever/manifests/sha256:abc", null), {
+      capabilities: ["delete"],
+      imageName: "someotherimage",
+    } as RegistryAuthProtocolTokenPayload);
+    expect(verified).toBeFalsy();
+  });
+
+  test("auth payload delete scoped to the same image can DELETE", async () => {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("DELETE", "/v2/whatever/manifests/sha256:abc", null), {
+      capabilities: ["delete"],
+      imageName: "whatever",
+    } as RegistryAuthProtocolTokenPayload);
+    expect(verified).toBeTruthy();
   });
 
   test("auth payload pull on /v2/whatever with mutations", async () => {
@@ -366,8 +408,8 @@ describe("tokens", async () => {
     }
   });
 
-  test("auth payload push/pull on /v2/whatever with mutations", async () => {
-    for (const mutationMethod of ["PATCH", "POST", "DELETE"]) {
+  test("auth payload push/pull on /v2/whatever with push mutations", async () => {
+    for (const mutationMethod of ["PATCH", "POST"]) {
       const { verified } = RegistryTokens.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
         capabilities: ["pull", "push"],
       } as RegistryAuthProtocolTokenPayload);


### PR DESCRIPTION
The destructive registry verbs (DELETE manifest, DELETE blob, and GC) shared a single capability check that only verified a `push` capability and skipped the per-image scope check entirely, so any push-capable token could delete or garbage collect any repository.

This separates destructive intent from write intent. DELETE and GC now require an explicit `delete` capability that is distinct from `push`, and every mutating verb (push uploads, manifest writes, deletes, and GC) is now enforced against the token's image scope so a token issued for one namespace can no longer act on another. Full-access basic-auth credentials carry the new capability so existing administrative flows keep working.

GC is dispatched over POST alongside blob upload initiation, so the check distinguishes the two by path: only the `/gc` route demands the delete capability.

Fixes SLS-223