### PR TITLE
fix: validate digest-addressed manifest uploads

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,7 +72,13 @@ export class InternalError extends Response {
 
 export class ManifestError extends Response {
   constructor(
-    code: "MANIFEST_INVALID" | "BLOB_UNKNOWN" | "MANIFEST_UNVERIFIED" | "TAG_INVALID" | "NAME_INVALID",
+    code:
+      | "MANIFEST_INVALID"
+      | "BLOB_UNKNOWN"
+      | "MANIFEST_UNVERIFIED"
+      | "TAG_INVALID"
+      | "NAME_INVALID"
+      | "DIGEST_INVALID",
     message: string,
     detail: Record<string, string> = {},
   ) {

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -533,6 +533,16 @@ export class R2Registry implements Registry {
     shaWriter.close();
     const digest = await sha256.digest;
     const digestStr = hexToDigest(digest);
+
+    if (reference.startsWith("sha256:") && reference !== digestStr) {
+      return {
+        response: new ManifestError(
+          "DIGEST_INVALID",
+          `provided digest ${reference} does not match content digest ${digestStr}`,
+        ),
+      };
+    }
+
     const text = await blob.text();
     const manifestJSON = JSON.parse(text);
     const manifest = manifestSchema.parse(manifestJSON);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -252,6 +252,33 @@ describe("v2 manifests", () => {
     await bindings.REGISTRY.delete(`${name}/manifests/${reference}`);
   });
 
+  test("PUT /v2/:name/manifests/:reference rejects a mismatched sha256 digest", async () => {
+    const name = "manifest-digest-mismatch";
+    const data = JSON.stringify(await generateManifest(name));
+    const contentDigest = await getSHA256(data);
+    const reference = `sha256:${"0".repeat(64)}`;
+    const response = await fetch(
+      createRequest("PUT", `/v2/${name}/manifests/${reference}`, new Blob([data]).stream(), {
+        "Content-Type": "application/gzip",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      errors: [
+        {
+          code: "DIGEST_INVALID",
+          message: `provided digest ${reference} does not match content digest ${contentDigest}`,
+          detail: {},
+        },
+      ],
+    });
+
+    const bindings = env as Env;
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${reference}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${contentDigest}`)).toBeNull();
+  });
+
   test("PUT then DELETE /v2/:name/manifests/:reference works", async () => {
     const { sha256 } = await createManifest("hello-world", await generateManifest("hello-world"), "hello");
     const bindings = env as Env;


### PR DESCRIPTION
Validates digest-addressed manifest uploads against the SHA-256 computed from the request body before any manifest object is written. Mismatches return the OCI-compatible `DIGEST_INVALID` client error, preserving the integrity guarantee of digest-pinned pulls.

Addresses SLS-305.