### PR TITLE
fix: normalize registry root authorization

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -75,7 +75,8 @@ export class RegistryTokens implements Authenticator {
   }
 
   static checkIfV2OnlyPath(request: Request): boolean {
-    return request.url.endsWith("/v2/");
+    const pathname = new URL(request.url).pathname;
+    return pathname === "/" || pathname === "/v2/";
   }
 
   static checkIfGarbageCollectionPath(request: Request): boolean {
@@ -139,18 +140,17 @@ export class RegistryTokens implements Authenticator {
         }
         break;
       // PULL method
-      case "GET":
-        if (RegistryTokens.checkIfV2OnlyPath(request)) {
-          return { verified: true, payload };
-        }
-
-        if (request.url == "https://registry.runpod.net/" || request.url == "https://registry.runpod.net") {
-          return { verified: true, payload };
-        }
-
-        if (RegistryTokens.checkIfV2OnlyPath(request) && payload.capabilities.length === 0) {
-          console.warn("verifyToken: failed jwt verification: missing any capabilities for GET request in /v2/");
+      case "GET": {
+        const isRegistryBasePath = RegistryTokens.checkIfV2OnlyPath(request);
+        if (isRegistryBasePath && payload.capabilities.length === 0) {
+          console.warn(
+            "verifyToken: failed jwt verification: missing any capabilities for GET request to registry base path",
+          );
           return { verified: false, payload: null };
+        }
+
+        if (isRegistryBasePath) {
+          return { verified: true, payload };
         }
 
         if (!payload.capabilities.includes("pull")) {
@@ -166,6 +166,7 @@ export class RegistryTokens implements Authenticator {
           return { verified: false, payload: null };
         }
         break;
+      }
 
       // PUSH methods
       case "POST":

--- a/src/token.ts
+++ b/src/token.ts
@@ -74,7 +74,7 @@ export class RegistryTokens implements Authenticator {
     return token;
   }
 
-  static checkIfV2OnlyPath(request: Request): boolean {
+  static checkIfRegistryBasePath(request: Request): boolean {
     const pathname = new URL(request.url).pathname;
     return pathname === "/" || pathname === "/v2/";
   }
@@ -141,7 +141,7 @@ export class RegistryTokens implements Authenticator {
         break;
       // PULL method
       case "GET": {
-        const isRegistryBasePath = RegistryTokens.checkIfV2OnlyPath(request);
+        const isRegistryBasePath = RegistryTokens.checkIfRegistryBasePath(request);
         if (isRegistryBasePath && payload.capabilities.length === 0) {
           console.warn(
             "verifyToken: failed jwt verification: missing any capabilities for GET request to registry base path",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -341,6 +341,30 @@ describe("tokens", async () => {
     expect(verified).toBeTruthy();
   });
 
+  test("auth payload without capabilities cannot GET registry base paths", async () => {
+    for (const url of ["https://registry.runpod.net/", "https://registry.com/v2/"]) {
+      const { verified } = RegistryTokens.verifyPayload(new Request(url), {
+        username: "test",
+        capabilities: [],
+        exp: Math.floor(Date.now() / 1000) + 60,
+        aud: url,
+      });
+      expect(verified).toBeFalsy();
+    }
+  });
+
+  test("auth payload push can GET the registry root on any host", async () => {
+    for (const url of ["https://registry.runpod.net/", "https://registry.example/?check=1"]) {
+      const { verified } = RegistryTokens.verifyPayload(new Request(url), {
+        username: "test",
+        capabilities: ["push"],
+        exp: Math.floor(Date.now() / 1000) + 60,
+        aud: url,
+      });
+      expect(verified).toBeTruthy();
+    }
+  });
+
   test("auth payload push on /v2/whatever with HEAD", async () => {
     const { verified } = RegistryTokens.verifyPayload(createRequest("HEAD", "/v2/whatever", null), {
       capabilities: ["push"],


### PR DESCRIPTION
Classifies `/` and `/v2/` as registry base paths using parsed URL pathnames, independent of deployment hostname. Base-path requests require a token with at least one capability, giving registry discovery consistent authorization semantics across custom domains.

Addresses SLS-306.